### PR TITLE
Fix mistakes in tests

### DIFF
--- a/test/iterators.scm
+++ b/test/iterators.scm
@@ -105,11 +105,11 @@
            (bitvector-map!/bool (constantly #t) bvec)
            (bitvector= bvec (bitvector #t #t #t #t)))
    => #t)
-  (check (let ((bvec#t (bitvector #t #f #f))
+  (check (let ((bvec1 (bitvector #t #f #f))
                (bvec2 (bitvector #f #t #f))
                (bvec3 (bitvector #f #f #t)))
-           (bitvector-map!/bool (lambda (a b c) b) bvec#t bvec2 bvec3)
-           (bitvector= bvec#t bvec2))
+           (bitvector-map!/bool (lambda (a b c) b) bvec1 bvec2 bvec3)
+           (bitvector= bvec1 bvec2))
    => #t)
 
 

--- a/test/quasi-string.scm
+++ b/test/quasi-string.scm
@@ -23,7 +23,10 @@
 
   ;;; pad & trim
 
-  (check (bitvector-pad 0 (bitvector 1) 4) => (bitvector 0 0 0 1))
+  (check (bitvector=
+          (bitvector-pad 0 (bitvector 1) 4)
+          (bitvector 0 0 0 1))
+   => #t)
   (let ((bvec (bitvector 1 0 1 0)))
     (check (bitvector= (bitvector-pad 0 bvec (bitvector-length bvec))
                        bvec)
@@ -31,8 +34,10 @@
     (check (bitvector= (bitvector-pad-right 0 bvec (bitvector-length bvec))
                        bvec)
      => #t))
-  (check (bitvector-pad-right 0 (bitvector 1) 4) => (bitvector 1 0 0 0))
-
+  (check (bitvector=
+          (bitvector-pad-right 0 (bitvector 1) 4)
+          (bitvector 1 0 0 0))
+   => #t)
   (check (bitvector= (bitvector-trim 0 (bitvector 0 0 0 1))
                      (bitvector 1))
    => #t)


### PR DESCRIPTION
These commits fix two minor issues with the SRFI 178 tests, reported by Jim Rees (https://srfi-email.schemers.org/srfi-178/msg/15052841/). The implementation and SRFI document are unaffected. Thanks.