### PR TITLE
Rename generators

### DIFF
--- a/srfi-178.html
+++ b/srfi-178.html
@@ -470,8 +470,8 @@ the resulting bitvector cannot be converted back by
 </p>
 <h3>Generators</h3>
 <p>
-<code>(make-bitvector-int-generator </code><em>bitvector</em><code>)</code> <br/>
-<code>(make-bitvector-bool-generator </code><em>bitvector</em><code>)</code> </p>
+<code>(make-bitvector/int-generator </code><em>bitvector</em><code>)</code> <br/>
+<code>(make-bitvector/bool-generator </code><em>bitvector</em><code>)</code> </p>
 <p>
 Returns a <a href="https://srfi.schemers.org/srfi-158/srfi-158.html">SRFI 158</a>
 generator that generates all the values of <em>bitvector</em> in order.


### PR DESCRIPTION
This fixes the names of the generator constructor procedures in the document. Thanks.