### PR TITLE
Fix merge damage

### DIFF
--- a/srfi/178/convert.scm
+++ b/srfi/178/convert.scm
@@ -43,13 +43,6 @@
       len
       int))))
 
-(define (integer->bitvector int)
-  (bitvector-unfold
-   (lambda (_ int)
-     (values (bit-set? 0 int) (arithmetic-shift int -1)))
-   (integer-length int)
-   int))
-
 ;;; Additional vector conversions
 
 (define reverse-vector->bitvector

--- a/srfi/178/convert.scm
+++ b/srfi/178/convert.scm
@@ -61,3 +61,27 @@
       (lambda (i)
         (vector-ref vec (- end 1 i)))
       (- end start)))))
+
+(define reverse-bitvector->vector/int
+  (case-lambda
+    ((bvec)
+     (reverse-bitvector->vector/int bvec 0 (bitvector-length bvec)))
+    ((bvec start)
+     (reverse-bitvector->vector/int bvec start (bitvector-length bvec)))
+    ((bvec start end)
+     (let ((u8vec (U bvec)))
+       (vector-unfold (lambda (i)
+                        (u8vector-ref u8vec (- end 1 i)))
+                      (- end start))))))
+
+(define reverse-bitvector->vector/bool
+  (case-lambda
+    ((bvec)
+     (reverse-bitvector->vector/bool bvec 0 (bitvector-length bvec)))
+    ((bvec start)
+     (reverse-bitvector->vector/bool bvec start (bitvector-length bvec)))
+    ((bvec start end)
+     (let ((u8vec (U bvec)))
+       (vector-unfold (lambda (i)
+                        (B (u8vector-ref u8vec (- end 1 i))))
+                      (- end start))))))

--- a/srfi/178/convert.scm
+++ b/srfi/178/convert.scm
@@ -49,3 +49,15 @@
      (values (bit-set? 0 int) (arithmetic-shift int -1)))
    (integer-length int)
    int))
+
+;;; Additional vector conversions
+
+(define reverse-vector->bitvector
+  (case-lambda
+    ((vec) (reverse-vector->bitvector vec 0 (vector-length vec)))
+    ((vec start) (reverse-vector->bitvector vec start (vector-length vec)))
+    ((vec start end)
+     (bitvector-unfold
+      (lambda (i)
+        (vector-ref vec (- end 1 i)))
+      (- end start)))))


### PR DESCRIPTION
Merge commits (cb055ee, in particular) deleted several new procedures and restored an outdated version of `integer->bitvector`.  These commits undo these changes.  Thanks.