### PR TITLE
Implementation: Fix erroneous fallback def. of vector-unfold.

### DIFF
--- a/srfi/178.sld
+++ b/srfi/178.sld
@@ -12,9 +12,10 @@
       ;; The "seedless" case is all we need.
       (define (vector-unfold f len)
         (let ((res (make-vector len)))
-          (cond ((= i len) res)
-                (else (vector-set! res i (f i))
-                      (lp (+ i 1)))))))))
+          (let lp ((i 0))
+            (cond ((= i len) res)
+                  (else (vector-set! res i (f i))
+                        (lp (+ i 1))))))))))
 
   (export bit->integer bit->boolean  ; Bit conversion
 


### PR DESCRIPTION
Unfortunately, this typo (first reported on the SRFI 196 mailing list) made it into the SRFI 178 implementation as well. This commit fixes it. Thanks.